### PR TITLE
CI: Build docs on develop (push/PR)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy Documentation
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - 'docs/**'
       - 'packages/**'
@@ -10,7 +10,7 @@ on:
       - 'firebase.json'
       - '.firebaserc'
   pull_request:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - 'docs/**'
       - 'packages/**'
@@ -20,7 +20,7 @@ on:
 
 env:
   NODE_VERSION: '20.x'
-  PNPM_VERSION: '8'
+  PNPM_VERSION: '10.14.0'
 
 jobs:
   deploy-docs-production:
@@ -37,7 +37,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: ${{ env.PNPM_VERSION }}
       - name: Setup pnpm cache
@@ -46,13 +46,13 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install
-      - name: Build documentation
+        run: pnpm install --no-frozen-lockfile
+      - name: Build packages
         run: |
-          cd docs
-          pnpm install --frozen-lockfile
-          pnpm build
-          ls -la build/
+          pnpm build:core
+          pnpm build:web
+      - name: Build documentation
+        run: pnpm docs:build
       - name: Deploy to Firebase Production Channel
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
@@ -75,7 +75,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: ${{ env.PNPM_VERSION }}
       - name: Setup pnpm cache
@@ -84,13 +84,13 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install
-      - name: Build documentation
+        run: pnpm install --no-frozen-lockfile
+      - name: Build packages
         run: |
-          cd docs
-          pnpm install --frozen-lockfile
-          pnpm build
-          ls -la build/
+          pnpm build:core
+          pnpm build:web
+      - name: Build documentation
+        run: pnpm docs:build
       - name: Deploy to Firebase Preview Channel
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
@@ -113,7 +113,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: ${{ env.PNPM_VERSION }}
       - name: Setup pnpm cache
@@ -122,13 +122,37 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install
-      - name: Build documentation
+        run: pnpm install --no-frozen-lockfile
+      - name: Build packages
         run: |
-          cd docs
-          pnpm install --frozen-lockfile
-          pnpm build
-          ls -la build/
+          pnpm build:core
+          pnpm build:web
+      - name: Build documentation
+        run: pnpm docs:build
+
+  build-docs-develop:
+    name: Build Docs (develop)
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/develop'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+      - name: Build packages
+        run: |
+          pnpm build:core
+          pnpm build:web
+      - name: Build documentation
+        run: pnpm docs:build
       - name: Deploy to Firebase Staging Channel
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,0 +1,38 @@
+name: Docs Build (develop)
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop]
+
+jobs:
+  build-docs:
+    name: Build Docusaurus Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.14.0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Build core package
+        run: pnpm build:core
+
+      - name: Build web package
+        run: pnpm build:web
+
+      - name: Build docs
+        run: pnpm docs:build


### PR DESCRIPTION
Adds GitHub Actions workflow to build Docusaurus docs on pushes and PRs to develop.\n\n- Uses pnpm and Node 20\n- Builds core and web first to satisfy docs dependencies\n- Runs pnpm docs:build\n\nThis will help catch MDX/TS errors early.